### PR TITLE
Add swicg/activitypub-api to repositories list

### DIFF
--- a/repositories.json
+++ b/repositories.json
@@ -16,6 +16,7 @@
   "swicg/miscellany",
   "swicg/forums",
   "swicg/activitypub-e2ee",
+  "swicg/activitypub-api",
   "swicg/activitypub-html-discovery",
   "swicg/activitypub-trust-and-safety",
   "swicg/activitypub-website-taskforce",


### PR DESCRIPTION
Adds [swicg/activitypub-api](https://github.com/swicg/activitypub-api) repo to the summary bot